### PR TITLE
added hidden_dimensions parameter to set all lkml with hidden=yes par…

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ dbt2looker --tag prod
 dbt2looker --exposed_only
 ```
 
+**Generate Looker view files with hidden=yes paramenter for all models**
+```shell
+dbt2looker --hidden_dimensions
+```
+
 ## Install
 
 **Install from PyPi repository**

--- a/dbt2looker_bigquery/cli.py
+++ b/dbt2looker_bigquery/cli.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from importlib_metadata import version
 
-from . import generator, parser
+from . import generator, parser, models
 
 MANIFEST_PATH = "./manifest.json"
 DEFAULT_LOOKML_OUTPUT_DIR = "."
@@ -95,6 +95,12 @@ def run():
     argparser.add_argument(
         "--select", help="select a specific model to generate lookml for", type=str
     )
+    argparser.add_argument(
+        "--hidden_dimensions",
+        "--hidden-dimensions",
+        help="add this flag to force generated dimensions to be hidden",
+        action='store_true'  # on/off flag
+    )
     args = argparser.parse_args()
     FORMAT = "%(message)s"
     logging.basicConfig(
@@ -117,6 +123,9 @@ def run():
     )
 
     adapter_type = parser.parse_adapter_type(raw_manifest)
+
+    if args.hidden_dimensions: 
+        models.HiddenDimension.is_hidden = args.hidden_dimensions
 
     # Generate lookml views
     lookml_views = [

--- a/dbt2looker_bigquery/generator.py
+++ b/dbt2looker_bigquery/generator.py
@@ -365,6 +365,10 @@ def lookml_dimensions_from_model(
                         column.meta.looker.value_format_name.value
                     )
 
+            #based on argument parser --hidden_dimensions
+            if models.HiddenDimension.is_hidden:
+                dimension["hidden"] = "yes"
+                
             is_hidden = False
             dimensions.append(dimension)
 

--- a/dbt2looker_bigquery/models.py
+++ b/dbt2looker_bigquery/models.py
@@ -247,3 +247,6 @@ class DbtManifest(BaseModel):
     nodes: Dict[str, Union[DbtModel, DbtNode]]
     metadata: DbtManifestMetadata
     exposures : Dict[str, DbtExposure]
+
+class HiddenDimension():
+    is_hidden = False    

--- a/dbt2looker_bigquery/models.py
+++ b/dbt2looker_bigquery/models.py
@@ -250,3 +250,4 @@ class DbtManifest(BaseModel):
 
 class HiddenDimension():
     is_hidden = False    
+    

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt2looker-bigquery"
-version = "0.14.0"
+version = "0.14.1"
 description = "Generate lookml view files from dbt models for Bigquery"
 requires_python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
This feature is to enable the user to set the hidden=yes parameter to all looker models by running `dbt2looker --hidden_dimensions` command.
For this I just added a new argument (--hidden_dimensions) on argparser with action "store_true", which means that it's False by default and set to True when the argument is written. 

Added a new class (HiddenDimension) to keep the variable **is_hidden**. This variable will be used on generator.py to set or not the hidden=yes parameter based on it's value.

The hidden=yes paramenter will be written on all lkml files only when this is set to True, i.e. only when you run `dbt2looker --hidden_dimensions` command.

Example with normal execution - `dbt2looker` command:
![Screenshot 2025-01-08 at 09 21 20](https://github.com/user-attachments/assets/f7cbc268-8757-4dc4-8089-499d3c51307e)

Example with `dbt2looker --hidden_dimensions` command:
![Screenshot 2025-01-08 at 09 24 15](https://github.com/user-attachments/assets/53195350-770c-44a0-a46c-4c6409a1d814)

