### PR TITLE
added changes for --skip-repeated-explore

### DIFF
--- a/dbt2looker_bigquery/cli.py
+++ b/dbt2looker_bigquery/cli.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from importlib_metadata import version
 
-from . import generator, parser
+from . import generator, parser, models
 
 MANIFEST_PATH = "./manifest.json"
 DEFAULT_LOOKML_OUTPUT_DIR = "."
@@ -95,6 +95,12 @@ def run():
     argparser.add_argument(
         "--select", help="select a specific model to generate lookml for", type=str
     )
+    argparser.add_argument(
+        "--skip-repeated-explore",
+        "--skip_repeated_explore",
+        help="add this flag to skip the explore view definition within the lkml view files",
+        action='store_true'  # on/off flag
+    )
     args = argparser.parse_args()
     FORMAT = "%(message)s"
     logging.basicConfig(
@@ -117,6 +123,9 @@ def run():
     )
 
     adapter_type = parser.parse_adapter_type(raw_manifest)
+
+    if args.skip_repeated_explore: 
+        models.SkipExplore.skip_explore = args.skip_repeated_explore    
 
     # Generate lookml views
     lookml_views = [

--- a/dbt2looker_bigquery/generator.py
+++ b/dbt2looker_bigquery/generator.py
@@ -721,7 +721,8 @@ def lookml_view_from_dbt_model(
             )
         return join_list
 
-    if len(array_models) > 0:
+    #also based on argument parser --skip_repeated_explore
+    if len(array_models) > 0 and not models.SkipExplore.skip_explore:
         logging.info(f"{model.name} explore view definition")
 
         hidden = "yes"

--- a/dbt2looker_bigquery/models.py
+++ b/dbt2looker_bigquery/models.py
@@ -250,3 +250,4 @@ class DbtManifest(BaseModel):
 
 class SkipExplore():
     skip_explore = False        
+

--- a/dbt2looker_bigquery/models.py
+++ b/dbt2looker_bigquery/models.py
@@ -247,3 +247,6 @@ class DbtManifest(BaseModel):
     nodes: Dict[str, Union[DbtModel, DbtNode]]
     metadata: DbtManifestMetadata
     exposures : Dict[str, DbtExposure]
+
+class SkipExplore():
+    skip_explore = False        


### PR DESCRIPTION
This second feature is to enable the user to skip the looker explores creation when there are repeated structs.
By simply run the command `dbt2looker --skip-repeated-explore` the views are generated accordingly and without the explore definition.

Testing with normal behavior by running `dbt2looker`:
![image](https://github.com/user-attachments/assets/89345002-ef11-4670-9a3e-3257ef339fb6)


Testing with new arg `dbt2looker --skip-repeated-explore`:
![image](https://github.com/user-attachments/assets/ff7d6bf8-4c37-4b4d-8676-ab955a9f6ef6)
