### PR TITLE
Fix for primary key not being detected

### DIFF
--- a/dbt2looker_bigquery/models/dbt.py
+++ b/dbt2looker_bigquery/models/dbt.py
@@ -171,7 +171,7 @@ class DbtModelColumn(BaseModel):
     def set_primary_key(cls, values):
         constraints = values.get("constraints", [])
 
-        if {"type": "primary_key"} in constraints:
+        if 'primary_key' in map(lambda x: x.get('type'), constraints):
             logging.debug("Found primary key constraint on %s model", values["name"])
             values["is_primary_key"] = True
 


### PR DESCRIPTION
`{"type": "primary_key"}` is not enough because the dictionary contains more keys. (@rognerud)

![Screenshot from 2025-05-07 11-33-04](https://github.com/user-attachments/assets/b80082d7-7bfd-4014-ac34-457976911972)
